### PR TITLE
user_specにexample追加

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,34 +6,34 @@ RSpec.describe User, type: :model do
     subject {user.valid?}
     context "データが条件を満たすとき" do
       let(:user) { build(:user) }
-      it "保存できる",type: :doing do
+      it "保存できる" do
         expect(subject).to eq true
       end
     end
     context "emailが空のとき" do
       let(:user) { build(:user, email: "") }
-      it "エラーが発生する",type: :running do
+      it "エラーが発生する" do
         expect(subject).to eq false
         expect(user.errors.messages[:email]).to include "を入力してください"
       end
     end
     context "パスワードが空のとき" do
       let(:user) { build(:user, password: "") }
-      it "エラーが発生する",type: :walking do
+      it "エラーが発生する" do
         expect(subject).to eq false
         expect(user.errors.messages[:password]).to include "を入力してください"
       end
     end
     context "usernameが空のとき" do
       let(:user) {build(:user, username: "")}
-      it "エラーが発生する",type: :jogging do
+      it "エラーが発生する" do
         expect(subject).to eq false
         expect(user.errors.messages[:username]).to include "を入力してください"
       end
     end
     context "username が20文字以上である時" do
       let(:user)  { build(:user,username: "a" * 21) }
-      it "エラーが発生する",type: :swimming do
+      it "エラーが発生する" do
         expect(subject).to eq false
         expect(user.errors.messages[:username]).to include "は20文字以内で入力してください"
       end
@@ -41,14 +41,23 @@ RSpec.describe User, type: :model do
     context "emailがすでに存在する時は無効である" do
       before { create(:user, email: "test@email.com") }
       let (:user) { build(:user, email: "test@email.com")}
-      it "エラーが発生する",type: :jumpping do
+      it "エラーが発生する" do
         expect(subject).to eq false
         expect(user.errors.messages[:email]).to include "はすでに存在します"
       end
     end
+
+    context "email が256文字以上のとき" do
+      let(:user) { build(:user, email: "a" * 256) }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(user.errors.messages[:email]).to include "は不正な値です"
+      end
+    end
+
     context "profileが空の時" do
       let(:user)  { build(:user,image: "") }
-      it "保存できる",type: :hopping do
+      it "保存できる" do
       expect(subject).to eq true
     end
     end


### PR DESCRIPTION
## 実装内容

- モデルスペックの追加
  - Userモデルにemailの文字数のバリデーション(255字超えるとエラー出るかどうか)確認のテストを追加

## 参考資料

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認